### PR TITLE
renaming predict function to posterior_predict

### DIFF
--- a/src/BFlux.jl
+++ b/src/BFlux.jl
@@ -12,7 +12,7 @@ export NetConstructor
 include("./likelihoods/abstract.jl")
 include("./likelihoods/feedforward.jl")
 include("./likelihoods/seq_to_one.jl")
-export BNNLikelihood, predict
+export BNNLikelihood, posterior_predict
 export FeedforwardNormal, FeedforwardTDist
 export SeqToOneNormal, SeqToOneTDist
 

--- a/src/likelihoods/abstract.jl
+++ b/src/likelihoods/abstract.jl
@@ -20,10 +20,10 @@ Every BNNLikelihood must be callable in the following way
 - `θlike` are the likelihood parameters. If no additional parameters were
   introduced, this will be an empty array
 
-Every BNNLikelihood must also implement a predict method which should draw from
+Every BNNLikelihood must also implement a posterior_predict method which should draw from
 the posterior predictive given network parameters and likelihood parameters. 
 
-    predict(l::BNNLikelihood, x, θnet, θlike)
+    posterior_predict(l::BNNLikelihood, x, θnet, θlike)
 
 - `l` the BNNLikelihood
 - `x` the input data 
@@ -43,4 +43,4 @@ function (l::BNNLikelihood)(
     error("Seems like your likelihood is not callable. Please see the documentation for BNNLikelihood.")
 end
 
-predict(l::BNNLikelihood, x, θnet, θlike) = error("Seems like your likelihood did not implement a predict method. Please see the documentation for BNNLikelihood.")
+posterior_predict(l::BNNLikelihood, x, θnet, θlike) = error("Seems like your likelihood did not implement a posterior_predict method. Please see the documentation for BNNLikelihood.")

--- a/src/likelihoods/feedforward.jl
+++ b/src/likelihoods/feedforward.jl
@@ -96,7 +96,7 @@ function (l::FeedforwardTDist{T,F,D})(x::Matrix{T}, y::Vector{T}, θnet::Abstrac
     return sum(logpdf.(TDist(l.ν), (y - yhat) ./ sigma)) - n * log(sigma) + logpdf(tdist, θlike[1])
 end
 
-function posterior_predictl(l::FeedforwardTDist{T,F,D}, x::Matrix{T}, θnet::AbstractVector, θlike::AbstractVector) where {T,F,D}
+function posterior_predict(l::FeedforwardTDist{T,F,D}, x::Matrix{T}, θnet::AbstractVector, θlike::AbstractVector) where {T,F,D}
     θnet = T.(θnet)
     θlike = T.(θlike)
 

--- a/src/likelihoods/feedforward.jl
+++ b/src/likelihoods/feedforward.jl
@@ -42,7 +42,7 @@ function (l::FeedforwardNormal{T,F,D})(x::Matrix{T}, y::Vector{T}, θnet::Abstra
     return logpdf(MvNormal(zeros(n), I), (y - yhat) ./ sigma) - n * log(sigma) + logpdf(tdist, θlike[1])
 end
 
-function predict(l::FeedforwardNormal{T,F,D}, x::Matrix{T}, θnet::AbstractVector, θlike::AbstractVector) where {T,F,D}
+function posterior_predict(l::FeedforwardNormal{T,F,D}, x::Matrix{T}, θnet::AbstractVector, θlike::AbstractVector) where {T,F,D}
     θnet = T.(θnet)
     θlike = T.(θlike)
 
@@ -96,7 +96,7 @@ function (l::FeedforwardTDist{T,F,D})(x::Matrix{T}, y::Vector{T}, θnet::Abstrac
     return sum(logpdf.(TDist(l.ν), (y - yhat) ./ sigma)) - n * log(sigma) + logpdf(tdist, θlike[1])
 end
 
-function predict(l::FeedforwardTDist{T,F,D}, x::Matrix{T}, θnet::AbstractVector, θlike::AbstractVector) where {T,F,D}
+function posterior_predictl(l::FeedforwardTDist{T,F,D}, x::Matrix{T}, θnet::AbstractVector, θlike::AbstractVector) where {T,F,D}
     θnet = T.(θnet)
     θlike = T.(θlike)
 

--- a/src/likelihoods/seq_to_one.jl
+++ b/src/likelihoods/seq_to_one.jl
@@ -43,7 +43,7 @@ function (l::SeqToOneNormal{T,F,D})(x::Array{T,3}, y::Vector{T}, θnet::Abstract
     return logpdf(MvNormal(zeros(n), I), (y - yhat) ./ sigma) - n * log(sigma) + logpdf(tdist, θlike[1])
 end
 
-function predict(l::SeqToOneNormal{T,F,D}, x::Array{T,3}, θnet::AbstractVector, θlike::AbstractVector) where {T,F,D}
+function posterior_predict(l::SeqToOneNormal{T,F,D}, x::Array{T,3}, θnet::AbstractVector, θlike::AbstractVector) where {T,F,D}
 
     θnet = T.(θnet)
     θlike = T.(θlike)
@@ -99,7 +99,7 @@ function (l::SeqToOneTDist{T,F,D})(x::Array{T,3}, y::Vector{T}, θnet::AbstractV
     return sum(logpdf.(TDist(l.ν), (y - yhat) ./ sigma)) - n * log(sigma) + logpdf(tdist, θlike[1])
 end
 
-function predict(l::SeqToOneTDist{T,F,D}, x::Array{T,3}, θnet::AbstractVector, θlike::AbstractVector) where {T,F,D}
+function posterior_predict(l::SeqToOneTDist{T,F,D}, x::Array{T,3}, θnet::AbstractVector, θlike::AbstractVector) where {T,F,D}
     θnet = T.(θnet)
     θlike = T.(θlike)
 

--- a/src/model/posterior.jl
+++ b/src/model/posterior.jl
@@ -1,7 +1,7 @@
 # Methods used for posterior analysis and predictions
 
 function posterior_predict(bnn::BNN, samples::Matrix{T}; kwargs...) where {T<:Real}
-    return predict(bnn, bnn.loglikelihood, samples; kwargs...)
+    return posterior_predict(bnn, bnn.loglikelihood, samples; kwargs...)
 end
 
 function posterior_predict(bnn::BNN, samples::Array{T,3}; kwargs...) where {T<:Real}

--- a/test/likelihoods.jl
+++ b/test/likelihoods.jl
@@ -33,7 +33,7 @@ Random.seed!(6150533)
         # Similarly, using any x should result in predictions that are 
         # distributed according to a standard normal
         x = randn(T, 10, 100_000)
-        ypp = predict(gl, x, θ, [tσ])
+        ypp = posterior_predict(gl, x, θ, [tσ])
         q = T.(quantile.([ypp], 0.1:0.1:0.9))
         @test maximum(abs, q - y) < 0.05
     end
@@ -59,7 +59,7 @@ Random.seed!(6150533)
 
         # And doing the same for prediction
         x = randn(T, 10, 100_000)
-        ypp = predict(tl, x, θ, [tσ])
+        ypp = posterior_predict(tl, x, θ, [tσ])
         q = T.(quantile.([ypp], 0.1:0.1:0.9))
         @test maximum(abs, q - y) < 0.05
     end
@@ -97,7 +97,7 @@ Random.seed!(6150533)
         # distributed according to a standard normal
         # x = [randn(T, 10, 100_000) for _ in 1:10]
         x = randn(T, 10, 10, 100_000)
-        ypp = predict(gl, x, θ, [tσ])
+        ypp = posterior_predict(gl, x, θ, [tσ])
         q = T.(quantile.([ypp], 0.1:0.1:0.9))
         @test maximum(abs, q - y) < 0.05
 
@@ -126,7 +126,7 @@ Random.seed!(6150533)
         # And doing the same for prediction
         # x = [randn(T, 10, 100_000) for _ in 1:10]
         x = randn(T, 10, 10, 100_000)
-        ypp = predict(tl, x, θ, [tσ])
+        ypp = posterior_predict(tl, x, θ, [tσ])
         q = T.(quantile.([ypp], 0.1:0.1:0.9))
         @test maximum(abs, q - y) < 0.05
     end


### PR DESCRIPTION
We previously got the warning the StatsBase.predict conflicts with an existing identifier. I traced this back to naming a function `predict`. This function was now renamed to `posterior_predict`.